### PR TITLE
 Accept generics when validating expression, argument and generator

### DIFF
--- a/src/main/scala/definiti/tests/validation/controls/expression/ValidExpressionTypeControl.scala
+++ b/src/main/scala/definiti/tests/validation/controls/expression/ValidExpressionTypeControl.scala
@@ -19,19 +19,21 @@ object ValidExpressionTypeControl extends Control[ValidationContext] {
 
   private def controlExpression(expression: ScopedExpression[Expression], context: ValidationContext): ControlResult = {
     val typ = expression.typeOfExpression
-    if (isTypeValid(typ, context)) {
+    if (isTypeValid(typ, context, expression.definedGenerics)) {
       ControlResult.OK
     } else {
       invalidType(typ, expression.location)
     }
   }
 
-  private def isTypeValid(typ: Type, context: ValidationContext): Boolean = {
-    context.getClassDefinition(typ.name)
+  private def isTypeValid(typ: Type, context: ValidationContext, generics: Seq[String]): Boolean = {
+    val isGeneric = generics.contains(typ.name)
+    val isValidClass = context.getClassDefinition(typ.name)
       .exists { classDefinition =>
         typ.generics.length == classDefinition.genericTypes.length &&
-          typ.generics.forall(isTypeValid(_, context))
+          typ.generics.forall(isTypeValid(_, context, generics))
       }
+    isGeneric || isValidClass
   }
 
   def invalidType(typ: Type, location: Location): Alert = {

--- a/src/main/scala/definiti/tests/validation/helpers/ScopedExpression.scala
+++ b/src/main/scala/definiti/tests/validation/helpers/ScopedExpression.scala
@@ -5,7 +5,13 @@ import definiti.tests.ast._
 import definiti.tests.validation.ValidationContext
 import definiti.tests.validation.helpers.ScopedExpression.TypeInfo
 
-case class ScopedExpression[E <: Expression](expression: E, references: Map[String, TypeInfo], generators: Seq[GeneratorMeta], library: Library) {
+case class ScopedExpression[E <: Expression](
+  expression: E,
+  references: Map[String, TypeInfo],
+  definedGenerics: Seq[String],
+  generators: Seq[GeneratorMeta],
+  library: Library
+) {
   // Natural logic of types is to not be generators.
   private implicit def typeAsTypeInfo(typ: Type): TypeInfo = TypeInfo(typ, isGenerator = false)
 
@@ -118,6 +124,7 @@ object ScopedExpression {
     new ScopedExpression(
       expression = expression,
       references = Map.empty,
+      definedGenerics = Seq.empty,
       generators = context.generators,
       library = context.library
     )
@@ -135,13 +142,20 @@ object ScopedExpression {
           }
         }.toMap
       },
+      definedGenerics = generator.generics,
       generators = context.generators,
       library = context.library
     )
   }
 
   def apply[E <: Expression](expression: E, innerScope: ScopedExpression[_]): ScopedExpression[E] = {
-    new ScopedExpression(expression, innerScope.references, innerScope.generators, innerScope.library)
+    new ScopedExpression(
+      expression = expression,
+      references = innerScope.references,
+      definedGenerics = innerScope.definedGenerics,
+      generators = innerScope.generators,
+      library = innerScope.library
+    )
   }
 
   implicit class scopedGenerator(scopedExpression: ScopedExpression[GenerationExpression]) {

--- a/src/test/resources/samples/controls/expression/methodArguments/invalidParameterWithGenerics.def
+++ b/src/test/resources/samples/controls/expression/methodArguments/invalidParameterWithGenerics.def
@@ -1,0 +1,3 @@
+context tests {{{
+  generator appendList[A, B](list: List[A], list2: List[B]): List[A] = list.appendAll(list2)
+}}}

--- a/src/test/resources/samples/controls/expression/methodArguments/validParameterWithGenerics.def
+++ b/src/test/resources/samples/controls/expression/methodArguments/validParameterWithGenerics.def
@@ -1,0 +1,3 @@
+context tests {{{
+  generator duplicateList[A](list: List[A]): List[A] = list.appendAll(list)
+}}}

--- a/src/test/resources/samples/controls/expression/validExpressionType/validGenerics.def
+++ b/src/test/resources/samples/controls/expression/validExpressionType/validGenerics.def
@@ -1,0 +1,3 @@
+context tests {{{
+  generator duplicateList[A](list: List[A]): List[A] = list.appendAll(list)
+}}}

--- a/src/test/resources/samples/controls/generator/expressionTypeOfGenerator/invalidGeneratorWithGenerics.def
+++ b/src/test/resources/samples/controls/generator/expressionTypeOfGenerator/invalidGeneratorWithGenerics.def
@@ -1,0 +1,3 @@
+context tests {{{
+  generator duplicateList[A](list: List[A]): List[String] = list.appendAll(list)
+}}}

--- a/src/test/resources/samples/controls/generator/expressionTypeOfGenerator/validGeneratorWithGenerics.def
+++ b/src/test/resources/samples/controls/generator/expressionTypeOfGenerator/validGeneratorWithGenerics.def
@@ -1,0 +1,3 @@
+context tests {{{
+  generator duplicateList[A](list: List[A]): List[A] = list.appendAll(list)
+}}}

--- a/src/test/scala/definiti/tests/end2end/controls/expression/MethodArgumentsControlSpec.scala
+++ b/src/test/scala/definiti/tests/end2end/controls/expression/MethodArgumentsControlSpec.scala
@@ -4,9 +4,8 @@ import definiti.common.ast.{Root, TypeReference}
 import definiti.common.program.Ko
 import definiti.common.tests.LocationPath
 import definiti.tests.ConfigurationBuilder
-import definiti.tests.ast.Type
 import definiti.tests.end2end.EndToEndSpec
-import definiti.tests.utils.CommonTypes.{any, string}
+import definiti.tests.utils.CommonTypes.string
 import definiti.tests.validation.controls.expression.MethodArgumentsControl
 
 class MethodArgumentsControlSpec extends EndToEndSpec {
@@ -34,6 +33,16 @@ class MethodArgumentsControlSpec extends EndToEndSpec {
       MethodArgumentsControl.invalidTypeOfArgument(TypeReference("Number"), string, invalidTypeOfArgumentLocation(4, 57, 60)),
       MethodArgumentsControl.invalidTypeOfArgument(TypeReference("Number"), string, invalidTypeOfArgumentLocation(6, 54, 57))
     ))
+  }
+
+  it should "accept an argument with the valid type of a generic" in {
+    val output = processFile("controls.expression.methodArguments.validParameterWithGenerics", configuration)
+    output shouldBe ok[Root]
+  }
+
+  it should "refuse an argument with the invalid type of a generic" in {
+    val output = processFile("controls.expression.methodArguments.invalidParameterWithGenerics", configuration)
+    output shouldBe ko[Root]
   }
 }
 

--- a/src/test/scala/definiti/tests/end2end/controls/expression/ValidExpressionTypeControlSpec.scala
+++ b/src/test/scala/definiti/tests/end2end/controls/expression/ValidExpressionTypeControlSpec.scala
@@ -77,6 +77,11 @@ class ValidExpressionTypeControlSpec extends EndToEndSpec {
     val output = processFile("controls.expression.validExpressionType.validGenConstTransformation", configuration)
     output shouldBe ok[Root]
   }
+
+  it should "validate an expression using generic types" in {
+    val output = processFile("controls.expression.validExpressionType.validGenerics", configuration)
+    output shouldBe ok[Root]
+  }
 }
 
 object ValidExpressionTypeControlSpec {

--- a/src/test/scala/definiti/tests/end2end/controls/generator/ExpressionTypeOfGeneratorControlSpec.scala
+++ b/src/test/scala/definiti/tests/end2end/controls/generator/ExpressionTypeOfGeneratorControlSpec.scala
@@ -37,6 +37,16 @@ class ExpressionTypeOfGeneratorControlSpec extends EndToEndSpec {
       ExpressionTypeOfGeneratorControl.invalidType(string, Type("Person"), invalidTypeForStructureLocation(8, 35, 10, 4))
     ))
   }
+
+  it should "validate an expression with the right generic" in {
+    val output = processFile("controls.generator.expressionTypeOfGenerator.validGeneratorWithGenerics", configuration)
+    output shouldBe ok[Root]
+  }
+
+  it should "invalidate an expression with the wrong generic" in {
+    val output = processFile("controls.generator.expressionTypeOfGenerator.invalidGeneratorWithGenerics", configuration)
+    output shouldBe ko[Root]
+  }
 }
 
 object ExpressionTypeOfGeneratorControlSpec {


### PR DESCRIPTION
When using generics, the compiler set a generator as invalid because it returned a generic type, defined itself in the function signature.

This PR corrects the behavior so generic types are accepted in expressions, arguments and generators.