### PR TITLE
Correct the control of field types for aliases

### DIFF
--- a/src/main/scala/definiti/tests/validation/controls/expression/MethodArgumentsControl.scala
+++ b/src/main/scala/definiti/tests/validation/controls/expression/MethodArgumentsControl.scala
@@ -35,7 +35,7 @@ object MethodArgumentsControl extends Control[ValidationContext] {
     methodDefinition.parameters.zip(methodCall.arguments)
       .map { case (parameter, argument) =>
         val typeOfArgument = Types.finalType(argument.typeOfExpression, context)
-        val scopedTypeOfParameter = ScopedType(parameter.typeReference, methodDefinition)
+        val scopedTypeOfParameter = ScopedType(parameter.typeReference, methodDefinition, context)
         if (scopedTypeOfParameter.isSameAs(typeOfArgument)) {
           ControlResult.OK
         } else {

--- a/src/main/scala/definiti/tests/validation/controls/expression/StructureControl.scala
+++ b/src/main/scala/definiti/tests/validation/controls/expression/StructureControl.scala
@@ -24,7 +24,7 @@ object StructureControl extends Control[ValidationContext] {
         ControlResult.squash {
           Seq(
             controlFieldList(structureExpression, definedType),
-            controlFieldTypes(structureExpression, definedType)
+            controlFieldTypes(structureExpression, definedType, context)
           )
         }
       case None =>
@@ -44,7 +44,7 @@ object StructureControl extends Control[ValidationContext] {
     (addedFields ++ missingFields).map(ControlResult(_))
   }
 
-  private def controlFieldTypes(structureExpression: ScopedExpression[StructureExpression], definedType: DefinedType): ControlResult = {
+  private def controlFieldTypes(structureExpression: ScopedExpression[StructureExpression], definedType: DefinedType, context: ValidationContext): ControlResult = {
     val fieldsWithAttributes = structureExpression.fields.flatMap { field =>
       definedType.attributes
         .find(_.name == field.name)
@@ -53,7 +53,7 @@ object StructureControl extends Control[ValidationContext] {
     fieldsWithAttributes.map { case (field, attribute) =>
       val fieldType = field.expression.typeOfExpression
       val attributeType = attribute.typeDeclaration
-      if (ScopedType(attributeType, definedType).isSameAs(fieldType)) {
+      if (ScopedType(attributeType, definedType, context).isSameAs(fieldType)) {
         ControlResult.OK
       } else {
         ControlResult(invalidType(Types.typeDeclarationToTypeReference(attributeType), fieldType, field.expression.location))

--- a/src/main/scala/definiti/tests/validation/controls/verificationTest/InputTypeForVerificationTestControl.scala
+++ b/src/main/scala/definiti/tests/validation/controls/verificationTest/InputTypeForVerificationTestControl.scala
@@ -28,7 +28,7 @@ object InputTypeForVerificationTestControl extends Control[ValidationContext] {
 
   private def controlTestCase(testCase: Case, verification: Verification, context: ValidationContext): ControlResult = {
     val typeReference = verification.function.parameters.head.typeReference
-    testCase.subCases.map(subCase => controlExpression(ScopedExpression(subCase.expression, context), ScopedType(typeReference, verification)))
+    testCase.subCases.map(subCase => controlExpression(ScopedExpression(subCase.expression, context), ScopedType(typeReference, verification, context)))
   }
 
   private def controlExpression(expression: ScopedExpression[Expression], scopedType: ScopedType): ControlResult = {

--- a/src/main/scala/definiti/tests/validation/controls/verificationTest/SubCaseVerificationMessageTypesControl.scala
+++ b/src/main/scala/definiti/tests/validation/controls/verificationTest/SubCaseVerificationMessageTypesControl.scala
@@ -48,7 +48,7 @@ object SubCaseVerificationMessageTypesControl extends Control[ValidationContext]
     if (typedMessage.types.length == subCase.messageArguments.length) {
       typedMessage.types.zip(subCase.messageArguments)
         .map { case (messageParameterType, caseArgument) =>
-          controlExpression(ScopedExpression(caseArgument, context), ScopedType(messageParameterType))
+          controlExpression(ScopedExpression(caseArgument, context), ScopedType(messageParameterType, context))
         }
     } else {
       invalidNumberOfParameters(typedMessage.types.length, subCase.messageArguments.length, subCase.location)

--- a/src/main/scala/definiti/tests/validation/controls/verificationTest/SubCaseVerificationReferenceTypesControl.scala
+++ b/src/main/scala/definiti/tests/validation/controls/verificationTest/SubCaseVerificationReferenceTypesControl.scala
@@ -34,7 +34,7 @@ object SubCaseVerificationReferenceTypesControl extends Control[ValidationContex
     if (verification.parameters.length == subCase.arguments.length) {
       verification.parameters.zip(subCase.arguments)
         .map { case (verificationParameter, caseArgument) =>
-          controlExpression(ScopedExpression(caseArgument, context), ScopedType(verificationParameter.typeReference, verification))
+          controlExpression(ScopedExpression(caseArgument, context), ScopedType(verificationParameter.typeReference, verification, context))
         }
     } else {
       invalidNumberOfParameters(verification.parameters.length, subCase.arguments.length, subCase.location)

--- a/src/main/scala/definiti/tests/validation/helpers/ScopedType.scala
+++ b/src/main/scala/definiti/tests/validation/helpers/ScopedType.scala
@@ -2,25 +2,30 @@ package definiti.tests.validation.helpers
 
 import definiti.common.ast._
 import definiti.tests.ast._
+import definiti.tests.validation.ValidationContext
 
-case class ScopedType(typeReference: AbstractTypeReference, generics: Seq[String]) {
+case class ScopedType(typeReference: AbstractTypeReference, generics: Seq[String], context: ValidationContext) {
   def isSameAs(typ: Type): Boolean = {
     typeReference match {
-      case typeReference: TypeReference => isSameAsTypeReference(typ, typeReference)
+      case typeReference: TypeReference =>
+        isSameAs(
+          typ = Types.finalType(typ, context),
+          reference = Types.finalType(Types.typeReferenceToType(typeReference), context)
+        )
       case _ => false
     }
   }
 
-  private def isSameAsTypeReference(typ: Type, typeReference: TypeReference): Boolean = {
-    if (generics.contains(typeReference.typeName)) {
+  private def isSameAs(typ: Type, reference: Type): Boolean = {
+    if (generics.contains(reference.name)) {
       true
     } else {
-      def sameTypeName = typ.name == typeReference.typeName
+      def sameTypeName = typ.name == reference.name
 
-      def sameNumberOfGenerics = typ.generics.length == typeReference.genericTypes.length
+      def sameNumberOfGenerics = typ.generics.length == reference.generics.length
 
-      def sameGenerics = typ.generics.zip(typeReference.genericTypes).forall { case (genericType, genericTypeReference) =>
-        isSameAsTypeReference(genericType, genericTypeReference)
+      def sameGenerics = typ.generics.zip(reference.generics).forall {
+        case (genericType, genericTypeReference) => isSameAs(genericType, genericTypeReference)
       }
 
       sameTypeName && sameNumberOfGenerics && sameGenerics
@@ -29,23 +34,23 @@ case class ScopedType(typeReference: AbstractTypeReference, generics: Seq[String
 }
 
 object ScopedType {
-  def apply(typeReference: AbstractTypeReference, verification: Verification): ScopedType = {
-    new ScopedType(typeReference, verification.function.genericTypes)
+  def apply(typeReference: AbstractTypeReference, verification: Verification, context: ValidationContext): ScopedType = {
+    new ScopedType(typeReference, verification.function.genericTypes, context)
   }
 
-  def apply(typeReference: AbstractTypeReference, definedType: DefinedType): ScopedType = {
-    new ScopedType(typeReference, definedType.genericTypes)
+  def apply(typeReference: AbstractTypeReference, definedType: DefinedType, context: ValidationContext): ScopedType = {
+    new ScopedType(typeReference, definedType.genericTypes, context)
   }
 
-  def apply(typeDeclaration: TypeDeclaration, definedType: DefinedType): ScopedType = {
-    new ScopedType(Types.typeDeclarationToTypeReference(typeDeclaration), definedType.genericTypes)
+  def apply(typeDeclaration: TypeDeclaration, definedType: DefinedType, context: ValidationContext): ScopedType = {
+    new ScopedType(Types.typeDeclarationToTypeReference(typeDeclaration), definedType.genericTypes, context)
   }
 
-  def apply(typeReference: AbstractTypeReference): ScopedType = {
-    new ScopedType(typeReference, Seq.empty)
+  def apply(typeReference: AbstractTypeReference, context: ValidationContext): ScopedType = {
+    new ScopedType(typeReference, Seq.empty, context)
   }
 
-  def apply(typeReference: AbstractTypeReference, methodDefinition: MethodDefinition): ScopedType = {
-    new ScopedType(typeReference, methodDefinition.genericTypes)
+  def apply(typeReference: AbstractTypeReference, methodDefinition: MethodDefinition, context: ValidationContext): ScopedType = {
+    new ScopedType(typeReference, methodDefinition.genericTypes, context)
   }
 }

--- a/src/test/resources/samples/controls/expression/structure/invalidAliasType.def
+++ b/src/test/resources/samples/controls/expression/structure/invalidAliasType.def
@@ -1,0 +1,21 @@
+type Person {
+  firstName: Name
+  lastName: Name
+}
+
+type Name = Number
+
+context tests {{{
+  test type Person {
+    accept
+      Person {
+        firstName: "First"
+        lastName: "Last"
+      }
+    refuse
+      Person {
+        firstName: ""
+        lastName: ""
+      }
+  }
+}}}

--- a/src/test/resources/samples/controls/expression/structure/validAliasType.def
+++ b/src/test/resources/samples/controls/expression/structure/validAliasType.def
@@ -1,0 +1,21 @@
+type Person {
+  firstName: Name
+  lastName: Name
+}
+
+type Name = String
+
+context tests {{{
+  test type Person {
+    accept
+      Person {
+        firstName: "First"
+        lastName: "Last"
+      }
+    refuse
+      Person {
+        firstName: ""
+        lastName: ""
+      }
+  }
+}}}

--- a/src/test/scala/definiti/tests/end2end/controls/expression/StructureControlSpec.scala
+++ b/src/test/scala/definiti/tests/end2end/controls/expression/StructureControlSpec.scala
@@ -86,6 +86,16 @@ class StructureControlSpec extends EndToEndSpec {
       StructureControl.fieldMissing("phone", Type("x.Contact"), invalidNestedTypeInListLocation(32, 31, 34, 8))
     ))
   }
+
+  it should "validate a structure with a field targeting a valid alias type" in {
+    val output = processFile("controls.expression.structure.validAliasType", configuration)
+    output shouldBe ok[Root]
+  }
+
+  it should "invalidate a structure with a field targeting an invalid alias type" in {
+    val output = processFile("controls.expression.structure.invalidAliasType", configuration)
+    output shouldBe ko[Root]
+  }
 }
 
 object StructureControlSpec {


### PR DESCRIPTION
In structure expressions, the control of field types does not work with aliases.
Aliases are not transformed into final types.

This commit does the following:

* `ScopedType` transforms types before checking if they are similar
* It requires the context so bubble up through the callers to get it
* Add tests ensuring the new control